### PR TITLE
Fix bug with swiping and state update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -468,6 +468,7 @@ module.exports = React.createClass({
                        contentContainerStyle={[styles.wrapper, this.props.style]}
                        contentOffset={this.state.offset}
                        onScrollBeginDrag={this.onScrollBegin}
+                       onScrollEndDrag={() => this.setState({ isScrolling: false })}
                        onMomentumScrollEnd={this.onScrollEnd}
                        onScroll={this.onScroll}
                        scrollEventThrottle={16}


### PR DESCRIPTION
This PR fixes a bug that prevents users from clicking next after swiping left on the first page of the app-intro.

[App-intro issue#60](https://github.com/FuYaoDe/react-native-app-intro/issues/60) needs this to be fixed.